### PR TITLE
Adding an additional attribute to allow disabling the appender

### DIFF
--- a/src/main/java/AirbrakeAppender.java
+++ b/src/main/java/AirbrakeAppender.java
@@ -59,9 +59,14 @@ public class AirbrakeAppender extends AbstractAppender {
       @PluginElement("Filter") final Filter filter,
       @PluginAttribute("projectId") int projectId,
       @PluginAttribute("projectKey") String projectKey,
-      @PluginAttribute("env") String env) {
+      @PluginAttribute("env") String env,
+      @PluginAttribute(value = "enabled", defaultBoolean = true) boolean enabled) {
     if (name == null) {
       LOGGER.error("No name provided for AirbrakeAppender");
+      return null;
+    }
+    if (!enabled) {
+      LOGGER.info("AirbrakeAppender is set to disabled, will not run.");
       return null;
     }
     return new AirbrakeAppender(name, filter, projectId, projectKey, env);

--- a/src/test/java/AirbrakeAppenderTest.java
+++ b/src/test/java/AirbrakeAppenderTest.java
@@ -31,7 +31,7 @@ public class AirbrakeAppenderTest {
     LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
 
     Configuration config = ctx.getConfiguration();
-    Appender appender = AirbrakeAppender.createAppender("Airbrake", null, 0, null, null);
+    Appender appender = AirbrakeAppender.createAppender("Airbrake", null, 0, null, null, true);
     appender.start();
     config.addAppender(appender);
 
@@ -50,6 +50,12 @@ public class AirbrakeAppenderTest {
   public void before() {
     notifier.setAsyncSender(sender);
     Airbrake.setNotifier(notifier);
+  }
+
+  @Test
+  public void testDisabled() {
+    AirbrakeAppender airbrakeAppender = AirbrakeAppender.createAppender("Airbrake", null, 0, null, null, false);
+    assertNull(airbrakeAppender);
   }
 
   @Test


### PR DESCRIPTION
The use case we are hitting is the appender running in both local and remote (server-side) environments. 
We'd like to be able to populate an environment variable that would determine whether the Airbrake appender would be enabled or not. This would be `true` on the server side, and `false` by default.