### PR TITLE
Send errors async and shutdown afterwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .gradle
+.project
+.settings/*
 build

--- a/src/main/java/AirbrakeAppender.java
+++ b/src/main/java/AirbrakeAppender.java
@@ -122,11 +122,12 @@ public class AirbrakeAppender extends AbstractAppender {
   }
 
   void send(Notice notice) {
-    CompletableFuture<Notice> result = CompletableFuture.supplyAsync(() -> {
+    CompletableFuture.runAsync(() -> {
       if (this.notifier != null) {
-        return this.notifier.sendSync(notice);
+        this.notifier.sendSync(notice);
+      } else {
+        Airbrake.sendSync(notice);
       }
-      return Airbrake.sendSync(notice);
     }, executorService);
   }
 

--- a/src/main/java/AirbrakeAppender.java
+++ b/src/main/java/AirbrakeAppender.java
@@ -1,8 +1,12 @@
 package io.airbrake.log4javabrake2;
+import static java.lang.Runtime.getRuntime;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Filter;
@@ -22,6 +26,7 @@ import io.airbrake.javabrake.NoticeError;
 
 @Plugin(name = "Airbrake", category = "Core", elementType = "appender", printObject = true)
 public class AirbrakeAppender extends AbstractAppender {
+  private ExecutorService executorService = newPool();
   Notifier notifier;
   String env;
 
@@ -32,6 +37,7 @@ public class AirbrakeAppender extends AbstractAppender {
       this.notifier = new Notifier(projectId, projectKey);
     }
     this.env = env;
+    getRuntime().addShutdownHook(new Thread(this::shutdown));
   }
 
   @Override
@@ -115,10 +121,41 @@ public class AirbrakeAppender extends AbstractAppender {
     return "trace";
   }
 
-  Future<Notice> send(Notice notice) {
-    if (this.notifier != null) {
-      return this.notifier.send(notice);
+  void send(Notice notice) {
+    ExecutorService execSvc = activeExecutorService();
+    CompletableFuture.runAsync(() -> {
+      if (this.notifier != null) {
+        this.notifier.sendSync(notice);
+      } else {
+        Airbrake.sendSync(notice);
+      }
+    }, execSvc).thenRun(() -> {
+      execSvc.shutdown();
+    });
+  }
+
+  private ExecutorService activeExecutorService() {
+    if (executorService.isShutdown()) {
+      executorService = newPool();
     }
-    return Airbrake.send(notice);
+
+    return executorService;
+  }
+
+  private ExecutorService newPool() {
+    return Executors.newFixedThreadPool(1);
+  }
+
+  void shutdown() {
+    executorService = activeExecutorService();
+    executorService.shutdown();
+    try {
+      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+        executorService.shutdownNow();
+      }
+    } catch (InterruptedException ex) {
+      executorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
   }
 }

--- a/src/test/java/AirbrakeAppenderTest.java
+++ b/src/test/java/AirbrakeAppenderTest.java
@@ -23,8 +23,7 @@ import io.airbrake.javabrake.NoticeStackFrame;
 
 public class AirbrakeAppenderTest {
   Notifier notifier = new Notifier(0, "");
-  Throwable exc = new IOException("hello from Java");
-  TestAsyncSender sender = new TestAsyncSender();
+  TestSyncSender sender = new TestSyncSender();
 
   @BeforeClass
   public static void beforeClass() {
@@ -48,14 +47,14 @@ public class AirbrakeAppenderTest {
 
   @Before
   public void before() {
-    notifier.setAsyncSender(sender);
+    notifier.setSyncSender(sender);
     Airbrake.setNotifier(notifier);
   }
 
   @Test
   public void testLogException() {
     Logger logger = LogManager.getLogger("io.airbrake.log4javabrake2");
-    logger.catching(exc);
+    logger.catching(new IOException("hello from Java"));
 
     NoticeError err = sender.notice.errors.get(0);
     assertEquals("java.io.IOException", err.type);
@@ -74,6 +73,6 @@ public class AirbrakeAppenderTest {
     NoticeStackFrame frame = err.backtrace[0];
     assertEquals("testLogMessage", frame.function);
     assertEquals("test/io/airbrake/log4javabrake2/AirbrakeAppenderTest.class", frame.file);
-    assertEquals(68, frame.line);
+    assertEquals(67, frame.line);
   }
 }

--- a/src/test/java/AirbrakeAppenderTest.java
+++ b/src/test/java/AirbrakeAppenderTest.java
@@ -24,7 +24,7 @@ import io.airbrake.javabrake.NoticeStackFrame;
 public class AirbrakeAppenderTest {
   Notifier notifier = new Notifier(0, "");
   Throwable exc = new IOException("hello from Java");
-  TestSyncSender sender = new TestSyncSender();
+  MockSyncSender sender = new MockSyncSender();
 
   @BeforeClass
   public static void beforeClass() {

--- a/src/test/java/AirbrakeAppenderTest.java
+++ b/src/test/java/AirbrakeAppenderTest.java
@@ -23,6 +23,7 @@ import io.airbrake.javabrake.NoticeStackFrame;
 
 public class AirbrakeAppenderTest {
   Notifier notifier = new Notifier(0, "");
+  Throwable exc = new IOException("hello from Java");
   TestSyncSender sender = new TestSyncSender();
 
   @BeforeClass
@@ -54,7 +55,8 @@ public class AirbrakeAppenderTest {
   @Test
   public void testLogException() {
     Logger logger = LogManager.getLogger("io.airbrake.log4javabrake2");
-    logger.catching(new IOException("hello from Java"));
+    logger.catching(exc);
+    shortPause();
 
     NoticeError err = sender.notice.errors.get(0);
     assertEquals("java.io.IOException", err.type);
@@ -65,6 +67,7 @@ public class AirbrakeAppenderTest {
   public void testLogMessage() {
     Logger logger = LogManager.getLogger("io.airbrake.log4javabrake2");
     logger.error("hello from Java");
+    shortPause();
 
     NoticeError err = sender.notice.errors.get(0);
     assertEquals("io.airbrake.log4javabrake2", err.type);
@@ -73,6 +76,12 @@ public class AirbrakeAppenderTest {
     NoticeStackFrame frame = err.backtrace[0];
     assertEquals("testLogMessage", frame.function);
     assertEquals("test/io/airbrake/log4javabrake2/AirbrakeAppenderTest.class", frame.file);
-    assertEquals(67, frame.line);
+    assertEquals(69, frame.line);
+  }
+
+  // shortPause sleeps the thread for a tiny amount of time to prevent exits
+  // before the executorService can do the work under test.
+  void shortPause() {
+    try { Thread.sleep(100); } catch(Exception e){}
   }
 }

--- a/src/test/java/MockSyncSender.java
+++ b/src/test/java/MockSyncSender.java
@@ -3,7 +3,7 @@ package io.airbrake.log4javabrake2;
 import io.airbrake.javabrake.Notice;
 import io.airbrake.javabrake.SyncSender;
 
-class TestSyncSender implements SyncSender {
+class MockSyncSender implements SyncSender {
   public Notice notice;
 
   @Override

--- a/src/test/java/TestSyncSender.java
+++ b/src/test/java/TestSyncSender.java
@@ -1,0 +1,17 @@
+package io.airbrake.log4javabrake2;
+
+import io.airbrake.javabrake.Notice;
+import io.airbrake.javabrake.SyncSender;
+
+class TestSyncSender implements SyncSender {
+  public Notice notice;
+
+  @Override
+  public Notice send(Notice notice) {
+    this.notice = notice;
+    return notice;
+  }
+
+  @Override
+  public void setHost(String host) {}
+}


### PR DESCRIPTION
In some cases the program exits before the error can be sent. This change ensures the error is sent asynchronously and shuts down the executor when the thread exits.