### PR TITLE
Increase version for log4javabrake2 and Javabrake

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Gradle:
 
 ```gradle
-compile 'io.airbrake:log4javabrake2:0.1.3'
+compile 'io.airbrake:log4javabrake2:0.1.4'
 ```
 
 Maven:
@@ -16,14 +16,14 @@ Maven:
 <dependency>
   <groupId>io.airbrake</groupId>
   <artifactId>log4javabrake2</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
 </dependency>
 ```
 
 Ivy:
 
 ```xml
-<dependency org='io.airbrake' name='log4javabrake2' rev='0.1.3'>
+<dependency org='io.airbrake' name='log4javabrake2' rev='0.1.4'>
   <artifact name='log4javabrake2' ext='pom'></artifact>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'java-library'
 apply plugin: 'io.codearte.nexus-staging'
 
 group = 'io.airbrake'
-version = '0.1.3'
+version = '0.1.4'
 
 if (project.hasProperty('signing.keyId')) {
   apply plugin: 'signing'
@@ -30,11 +30,11 @@ repositories {
 }
 
 dependencies {
-    compile 'io.airbrake:javabrake:0.1.+'
-    compile 'org.apache.logging.log4j:log4j-api:2.8.+'
-    compile 'org.apache.logging.log4j:log4j-core:2.8.+'
+    compile 'io.airbrake:javabrake:0.1.6'
+    compile 'org.apache.logging.log4j:log4j-api:2.8.2'
+    compile 'org.apache.logging.log4j:log4j-core:2.8.2'
 
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.12'
 }
 
 test {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.airbrake</groupId>
   <artifactId>log4javabrake2</artifactId>
-  <version>0.1.2</version>
+  <version>0.1.4</version>
   <inceptionYear>2017</inceptionYear>
   <licenses>
     <license>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.airbrake</groupId>
       <artifactId>javabrake</artifactId>
-      <version>0.1.2</version>
+      <version>0.1.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bump the version and upgrade javabrake dependency. There were a few errors with the version specifications in the build.gradle file that have been corrected by using the exact versions.