### PR TITLE
Upgrade log4j and bump notifier version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Gradle:
 
 ```gradle
-compile 'io.airbrake:log4javabrake2:0.1.5'
+compile 'io.airbrake:log4javabrake2:0.1.6'
 ```
 
 Maven:
@@ -16,14 +16,14 @@ Maven:
 <dependency>
   <groupId>io.airbrake</groupId>
   <artifactId>log4javabrake2</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
 </dependency>
 ```
 
 Ivy:
 
 ```xml
-<dependency org='io.airbrake' name='log4javabrake2' rev='0.1.5'>
+<dependency org='io.airbrake' name='log4javabrake2' rev='0.1.6'>
   <artifact name='log4javabrake2' ext='pom'></artifact>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'java-library'
 apply plugin: 'io.codearte.nexus-staging'
 
 group = 'io.airbrake'
-version = '0.1.5'
+version = '0.1.6'
 
 if (project.hasProperty('signing.keyId')) {
   apply plugin: 'signing'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.airbrake</groupId>
   <artifactId>log4javabrake2</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
   <inceptionYear>2017</inceptionYear>
   <licenses>
     <license>


### PR DESCRIPTION
This brings in the latest version of log4j and bumps our notifier version of log4javabrake2 to `0.1.6`.